### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Go CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/weka/amg-utils/security/code-scanning/5](https://github.com/weka/amg-utils/security/code-scanning/5)

The best way to fix this issue is to explicitly set the `permissions` key at the workflow root level (so it applies to all jobs unless overridden), or at the individual job level if particular jobs require different permissions. For this workflow, neither job appears to require any write access—both are just checking out code, running tests, building, caching dependencies, etc.—so `contents: read` should be sufficient. To implement the fix, add the following block immediately after the `name: Go CI` line (after line 1) in `.github/workflows/go-ci.yml`:

```yaml
permissions:
  contents: read
```

This addition limits the permissions of the GITHUB_TOKEN, ensuring only read access to repository contents, and aligns the workflow with the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
