### PR TITLE
image build bug fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     libffi-dev \
     python3-dev \
+    python3-venv \
     gds-tools-12-9 \
     libcufile-12-9 \
     librdmacm1 \
@@ -66,15 +67,16 @@ ENV PATH="/root/.local/bin:${PATH}"
 RUN wget https://github.com/weka/amg-utils/releases/download/${AMG_UTILS_VERSION}/amgctl-linux-amd64 -O /usr/local/bin/amgctl && \
     chmod +x /usr/local/bin/amgctl
 
-# Setup host with amgctl (use upstream LMCache and VLLM)
-# The amgctl binary now automatically detects CUDA version and uses appropriate PyTorch index
-RUN amgctl host setup
-
-# Activate uv environment on login
-RUN echo "source /root/amg_stable/.venv/bin/activate" >> /root/.bashrc
-
 # Set working directory
 WORKDIR /root/amg_stable
 
+# Activate uv environment on login
+RUN uv venv .venv
+RUN echo "source /root/amg_stable/.venv/bin/activate" >> /root/.bashrc
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Run AMGCTL at container start time where nvidia runtime is available - supports cross and local builds
+ENTRYPOINT [ "entrypoint.sh" ]
 # Set default command
 CMD ["/bin/bash"] 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# -*- indent-tabs-mode: nil; tab-width: 2; sh-indentation: 2; -*-
+
+# Entrypoint script for the amg container - helpful because the container can start in non-GPU environments for debugging purposes
+
+set -euo pipefail
+
+# helper functions
+log()   { printf '%s %s\n' "$(date +'%FT%T%z')" "$*" >&2; }
+fatal() { printf '%s %s\n' "$(date +'%FT%T%z')" "$*" >&2; exit 90; }
+have_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+is_gpu_env() {
+  [ -e /dev/nvidiactl ] && return 0
+  [ -e /dev/nvidia0 ] && return 0
+  [ -e /proc/driver/nvidia/version ] && return 0
+  have_cmd nvidia-smi && return 0
+  { [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "${CUDA_VISIBLE_DEVICES}" != "-1" ]; } && return 0
+  return 1
+}
+
+main() {
+  if ! is_gpu_env; then
+    log "INFO: No NVIDIA GPUs detected; skipping 'amgctl host setup'."
+    exec "$@"
+  fi
+
+  log "INFO: NVIDIA/GPU environment detected; running 'amgctl host setup'."
+
+  have_cmd amgctl || fatal "FATAL: 'amgctl' not found in PATH."
+
+  amgctl host setup
+  log "INFO: 'amgctl host setup' completed successfully."
+
+  exec "$@"
+}
+
+main "$@"


### PR DESCRIPTION
Howdy folks, was trying to build an image to test out the k8s stuff. In the process I found some bugs / things that I think we can optimize:

Bugfix: `/root/amg_stable/.venv/bin/activate: No such file or directory` -- every time at startup it would try to source in a virtual environment without having one been created

QOL fix: Builds should be doable even without GPUs. This PR adds an `entrypoint` that enables the checking of the Nvidia runtime at container runtime - which is correct. If desired, you can remove the changes to enable this container to start without access to a GPU runtime, and make it strict, but in either case this should happen at runtime and not at build time.

